### PR TITLE
Added support for custom namespace (LogMetric)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,7 +188,7 @@ class AlertsPlugin {
     const logMetricCFRefOK = `${logMetricCFRefBase}OK`;
 
     const cfLogName = this.providerNaming.getLogGroupLogicalId(functionName);
-    const metricNamespace = this.providerNaming.getStackName();
+    const metricNamespace = alarm.namespace ? alarm.namespace : this.providerNaming.getStackName();
     const logGroupName = this.providerNaming.getLogGroupName(functionObj.name);
     const metricName = this.naming.getPatternMetricName(alarm.metric, normalizedFunctionName);
     const metricValue = alarm.metricValue ? alarm.metricValue : 1;

--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ class AlertsPlugin {
     }
 
     const namespace = definition.pattern ?
-      this.awsProvider.naming.getStackName() :
+      (definition.namespace ? definition.namespace : this.awsProvider.naming.getStackName()) :
       definition.namespace;
 
     const metricName = definition.pattern ?


### PR DESCRIPTION
## What did you implement:

Allows for custom namespaces within LogMetric config

## How did you implement it:

N/A

## How can we verify it:

Define a custom alarm and include the namespace attribute

```custom:
  alerts:
    function:
      - name: barAlarm
        namespace: custom/Namespace/here
        metric: barExceptions
        threshold: 0
        statistic: Minimum
        period: 60
        evaluationPeriods: 1
        comparisonOperator: GreaterThanThreshold
        pattern: 'exception Bar'
